### PR TITLE
Use parameterized header name for REMOTE_USER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ pip-log.txt
 
 # PyCharm
 .idea
+
+*.sublime-project
+*.sublime-workspace

--- a/shibboleth/app_settings.py
+++ b/shibboleth/app_settings.py
@@ -28,5 +28,9 @@ LOGOUT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_URL', None)
 LOGOUT_REDIRECT_URL = getattr(settings, 'SHIBBOLETH_LOGOUT_REDIRECT_URL', None)
 #Name of key.  Probably no need to change this.  
 LOGOUT_SESSION_KEY = getattr(settings, 'SHIBBOLETH_FORCE_REAUTH_SESSION_KEY', 'shib_force_reauth')
+# The Django middleware accepts an optional attribute
+# specifying the name of the header which contains the remote user
+SHIB_REMOTE_USER_HEADER_NAME = getattr(settings, 'SHIB_REMOTE_USER_HEADER_NAME', 'REMOTE_USER')
+SHIB_SKIP_SHIB_AUTH_FOR_ADMIN = getattr(settings, 'SHIB_SKIP_SHIB_AUTH_FOR_ADMIN', False)
 
 


### PR DESCRIPTION
Since we're running django in a reverse proxy configuration, Apache
obviously can't inject CGI variables such as REMOTE_USER. The django
shibboleth app looks for this header and dails silently when it doesn't
see it. This fixes that to use a parameterized header name.